### PR TITLE
Make substitution of env.template lines match anything for the values.

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -313,12 +313,12 @@ set_variables() {
 
     if grep -q '^#MC_PORT=' .env && [ "$HTTP_PORT" != "$DEFAULT_HTTP_PORT" ]; then
         log_info "Using non-standard HTTP_PORT=${HTTP_PORT}"
-        portable_sed_i "s|^#MC_PORT=${DEFAULT_HTTP_PORT}|MC_PORT=${HTTP_PORT}|" .env
+        portable_sed_i "s|^#MC_PORT=.*|MC_PORT=${HTTP_PORT}|" .env
     fi
 
     if grep -q '^#MC_SSL_PORT=' .env && [ "$HTTPS_PORT" != "$DEFAULT_HTTPS_PORT" ]; then
         log_info "Using non-standard HTTPS_PORT=${HTTPS_PORT}"
-        portable_sed_i "s|^#MC_SSL_PORT=${DEFAULT_HTTPS_PORT}|MC_SSL_PORT=${HTTPS_PORT}|" .env
+        portable_sed_i "s|^#MC_SSL_PORT=.*|MC_SSL_PORT=${HTTPS_PORT}|" .env
     fi
 
     # Determine if SSL is being used to serve Mission Control.
@@ -330,7 +330,7 @@ set_variables() {
     # Check if xgt.lic license file exists
     if [ -f xgt.lic ]; then
         log_info "Custom license file found."
-        portable_sed_i "s|^#XGT_LICENSE_FILE=/path/to/license/xgt-license.lic|XGT_LICENSE_FILE=$(pwd)/xgt.lic|" .env
+        portable_sed_i "s|^#XGT_LICENSE_FILE=.*|XGT_LICENSE_FILE=$(pwd)/xgt.lic|" .env
     fi
 
     # Comment out empty authorization list to enable multi-user auth.
@@ -346,7 +346,7 @@ deploy_containers() {
 
     if [ "$arch" = "ppc64le" ]; then
         export MC_MONGODB_IMAGE=ibmcom/mongodb-ppc64le
-        portable_sed_i 's|^#MC_MONGODB_IMAGE=mongo:latest|MC_MONGODB_IMAGE=ibmcom/mongodb-ppc64le|' .env
+        portable_sed_i 's|^#MC_MONGODB_IMAGE=.*|MC_MONGODB_IMAGE=ibmcom/mongodb-ppc64le|' .env
     fi
 
     log_info "Pulling latest container images."


### PR DESCRIPTION
The sed lines were matching against a set value for the environment variables.  I had to change the line for MC_MONGODB_IMAGE because I changed the default for that in env.template.  To avoid having to change these in the future when the defaults for the variables are changed in env.template, I changed the substitution lines to match against any value for the environment variable.